### PR TITLE
log -> logrus

### DIFF
--- a/internal/provider/logging_transport.go
+++ b/internal/provider/logging_transport.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/internal/provider/provider_config.go
+++ b/internal/provider/provider_config.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 
 	"github.com/hashicorp/go-cleanhttp"

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"testing"

--- a/internal/provider/resource_chrome_policy.go
+++ b/internal/provider/resource_chrome_policy.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strconv"
 	"strings"

--- a/internal/provider/resource_domain.go
+++ b/internal/provider/resource_domain.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_domain_alias.go
+++ b/internal/provider/resource_domain_alias.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_domain_alias_sweeper_test.go
+++ b/internal/provider/resource_domain_alias_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/resource_domain_sweeper_test.go
+++ b/internal/provider/resource_domain_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/resource_gmail_send_as_alias.go
+++ b/internal/provider/resource_gmail_send_as_alias.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/resource_group_member.go
+++ b/internal/provider/resource_group_member.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_group_members.go
+++ b/internal/provider/resource_group_members.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 

--- a/internal/provider/resource_group_settings.go
+++ b/internal/provider/resource_group_settings.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"time"
 

--- a/internal/provider/resource_group_sweeper_test.go
+++ b/internal/provider/resource_group_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/resource_org_unit.go
+++ b/internal/provider/resource_org_unit.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	directory "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/googleapi"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func resourceOrgUnit() *schema.Resource {

--- a/internal/provider/resource_org_unit_sweeper_test.go
+++ b/internal/provider/resource_org_unit_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 
 	"github.com/hashicorp/go-cty/cty"

--- a/internal/provider/resource_role_assignment.go
+++ b/internal/provider/resource_role_assignment.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/internal/provider/resource_role_sweeper_test.go
+++ b/internal/provider/resource_role_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/resource_schema_sweeper_test.go
+++ b/internal/provider/resource_schema_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/mail"
 	"reflect"
 	"strconv"

--- a/internal/provider/resource_user_sweeper_test.go
+++ b/internal/provider/resource_user_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/retry_predicates.go
+++ b/internal/provider/retry_predicates.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/internal/provider/retry_transport.go
+++ b/internal/provider/retry_transport.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"google.golang.org/api/googleapi"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/http/httputil"
 	"time"

--- a/internal/provider/retry_utils.go
+++ b/internal/provider/retry_utils.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"time"
 

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -4,7 +4,7 @@
 package googleworkspace
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/mail"
 	"os"
 	"reflect"

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-provider-googleworkspace/internal/provider"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)